### PR TITLE
feat: Separate the module of sdk-spi-aws to multiple modules

### DIFF
--- a/capa-spi-aws-config/pom.xml
+++ b/capa-spi-aws-config/pom.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>capa-aws-parent</artifactId>
+        <groupId>group.rxcloud</groupId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>capa-spi-aws-config</artifactId>
+    <name>capa-skd-spi-aws-appconfig</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>group.rxcloud</groupId>
+            <artifactId>capa-spi-aws-infrastructure</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>appconfig</artifactId>
+        </dependency>
+        <!-- unit test -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- With JUnit 5 explicitely needed to let our tests run with Maven & as there seems to be a transitively
+			 added older surefire-plugin, that doesnt support JUnit 5 as described in https://stackoverflow.com/a/49019437/4964553 -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${maven.jacoco.version}</version>
+                <executions>
+                    <!-- Prepares the property pointing to the JaCoCo
+                    runtime agent which is passed as VM argument when Maven the Surefire plugin
+                    is executed. -->
+                    <execution>
+                        <id>pre-unit-test</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <!-- Ensures that the code coverage report for
+                    unit tests is created after unit tests have been run. -->
+                    <execution>
+                        <id>post-unit-test</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/capa-spi-aws-config/src/main/java/group/rxcloud/capa/spi/aws/config/AwsCapaConfiguration.java
+++ b/capa-spi-aws-config/src/main/java/group/rxcloud/capa/spi/aws/config/AwsCapaConfiguration.java
@@ -14,12 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package group.rxcloud.capa.spi.aws.configuration;
+package group.rxcloud.capa.spi.aws.config;
 
 import group.rxcloud.capa.component.configstore.CapaConfigStore;
 import group.rxcloud.capa.infrastructure.serializer.CapaObjectSerializer;
-import group.rxcloud.capa.spi.aws.config.AwsClientProviderLoader;
-import group.rxcloud.cloudruntimes.utils.TypeRef;
 import software.amazon.awssdk.services.appconfig.AppConfigAsyncClient;
 
 /**
@@ -36,9 +34,7 @@ public class AwsCapaConfiguration extends CapaConfigStore {
      */
     public AwsCapaConfiguration(CapaObjectSerializer objectSerializer) {
         super(objectSerializer);
-
-        TypeRef<AppConfigAsyncClient> ref = TypeRef.get(AppConfigAsyncClient.class);
-        appConfigAsyncClient = AwsClientProviderLoader.load(ref);
+        appConfigAsyncClient = AppConfigAsyncClient.create();
     }
 
     @Override

--- a/capa-spi-aws-config/src/main/java/group/rxcloud/capa/spi/aws/config/package-info.java
+++ b/capa-spi-aws-config/src/main/java/group/rxcloud/capa/spi/aws/config/package-info.java
@@ -15,4 +15,4 @@
  * limitations under the License.
  */
 
-package group.rxcloud.capa.spi.aws;
+package group.rxcloud.capa.spi.aws.config;

--- a/capa-spi-aws-infrastructure/pom.xml
+++ b/capa-spi-aws-infrastructure/pom.xml
@@ -26,8 +26,8 @@
         <version>${revision}</version>
     </parent>
 
-    <artifactId>sdk-spi-aws</artifactId>
-    <name>capa-sdk-spi-aws</name>
+    <artifactId>capa-spi-aws-infrastructure</artifactId>
+    <name>capa-sdk-spi-aws-infrastructure</name>
     <packaging>jar</packaging>
 
     <dependencies>
@@ -35,43 +35,6 @@
         <dependency>
             <groupId>group.rxcloud</groupId>
             <artifactId>capa-sdk-spi</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>appconfig</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>s3</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>dynamodb</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>appmesh</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>cloudwatch</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>rds</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>sns</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>sqs</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>software.amazon.awssdk</groupId>
-            <artifactId>xray</artifactId>
         </dependency>
         <!-- unit test -->
         <dependency>

--- a/capa-spi-aws-mesh/pom.xml
+++ b/capa-spi-aws-mesh/pom.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>capa-aws-parent</artifactId>
+        <groupId>group.rxcloud</groupId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>capa-spi-aws-mesh</artifactId>
+    <name>capa-skd-spi-aws-appmesh</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>group.rxcloud</groupId>
+            <artifactId>capa-spi-aws-infrastructure</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>appmesh</artifactId>
+        </dependency>
+        <!-- unit test -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- With JUnit 5 explicitely needed to let our tests run with Maven & as there seems to be a transitively
+			 added older surefire-plugin, that doesnt support JUnit 5 as described in https://stackoverflow.com/a/49019437/4964553 -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${maven.jacoco.version}</version>
+                <executions>
+                    <!-- Prepares the property pointing to the JaCoCo
+                    runtime agent which is passed as VM argument when Maven the Surefire plugin
+                    is executed. -->
+                    <execution>
+                        <id>pre-unit-test</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <!-- Ensures that the code coverage report for
+                    unit tests is created after unit tests have been run. -->
+                    <execution>
+                        <id>post-unit-test</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/capa-spi-aws-mesh/src/main/java/group/rxcloud/capa/spi/aws/mesh/config/AwsClientProviderLoader.java
+++ b/capa-spi-aws-mesh/src/main/java/group/rxcloud/capa/spi/aws/mesh/config/AwsClientProviderLoader.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package group.rxcloud.capa.spi.aws.config;
+package group.rxcloud.capa.spi.aws.mesh.config;
 
 import group.rxcloud.cloudruntimes.utils.TypeRef;
 import software.amazon.awssdk.core.SdkClient;

--- a/capa-spi-aws-mesh/src/main/java/group/rxcloud/capa/spi/aws/mesh/config/AwsRpcServiceOptions.java
+++ b/capa-spi-aws-mesh/src/main/java/group/rxcloud/capa/spi/aws/mesh/config/AwsRpcServiceOptions.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package group.rxcloud.capa.spi.aws.config;
+package group.rxcloud.capa.spi.aws.mesh.config;
 
 import group.rxcloud.capa.infrastructure.env.CapaEnvironment;
 import group.rxcloud.capa.spi.config.RpcServiceOptions;
@@ -53,7 +53,7 @@ public class AwsRpcServiceOptions implements RpcServiceOptions {
      */
     public enum ServiceRpcInvokeMode {
         /**
-         * AWS → AWS
+         * AWS to AWS
          */
         AWS_TO_AWS,
         ;

--- a/capa-spi-aws-mesh/src/main/java/group/rxcloud/capa/spi/aws/mesh/config/AwsSpiOptionsLoader.java
+++ b/capa-spi-aws-mesh/src/main/java/group/rxcloud/capa/spi/aws/mesh/config/AwsSpiOptionsLoader.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package group.rxcloud.capa.spi.aws.config;
+package group.rxcloud.capa.spi.aws.mesh.config;
 
 import group.rxcloud.capa.infrastructure.env.CapaEnvironment;
 import group.rxcloud.capa.spi.config.CapaSpiOptionsLoader;

--- a/capa-spi-aws-mesh/src/main/java/group/rxcloud/capa/spi/aws/mesh/http/AwsCapaHttp.java
+++ b/capa-spi-aws-mesh/src/main/java/group/rxcloud/capa/spi/aws/mesh/http/AwsCapaHttp.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package group.rxcloud.capa.spi.aws.http;
+package group.rxcloud.capa.spi.aws.mesh.http;
 
 import group.rxcloud.capa.component.http.HttpResponse;
 import group.rxcloud.capa.infrastructure.serializer.CapaObjectSerializer;

--- a/capa-spi-aws-mesh/src/main/java/group/rxcloud/capa/spi/aws/mesh/package-info.java
+++ b/capa-spi-aws-mesh/src/main/java/group/rxcloud/capa/spi/aws/mesh/package-info.java
@@ -15,4 +15,4 @@
  * limitations under the License.
  */
 
-package group.rxcloud.capa.spi.aws.configuration;
+package group.rxcloud.capa.spi.aws.mesh;

--- a/capa-spi-aws/pom.xml
+++ b/capa-spi-aws/pom.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>capa-aws-parent</artifactId>
+        <groupId>group.rxcloud</groupId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>capa-spi-aws</artifactId>
+    <name>capa-spi-aws</name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>group.rxcloud</groupId>
+            <artifactId>capa-spi-aws-mesh</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>group.rxcloud</groupId>
+            <artifactId>capa-spi-aws-config</artifactId>
+        </dependency>
+        <!-- unit test -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- With JUnit 5 explicitely needed to let our tests run with Maven & as there seems to be a transitively
+			 added older surefire-plugin, that doesnt support JUnit 5 as described in https://stackoverflow.com/a/49019437/4964553 -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${maven.jacoco.version}</version>
+                <executions>
+                    <!-- Prepares the property pointing to the JaCoCo
+                    runtime agent which is passed as VM argument when Maven the Surefire plugin
+                    is executed. -->
+                    <execution>
+                        <id>pre-unit-test</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <!-- Ensures that the code coverage report for
+                    unit tests is created after unit tests have been run. -->
+                    <execution>
+                        <id>post-unit-test</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/capa-spi-aws/src/main/resources/capa-component.properties
+++ b/capa-spi-aws/src/main/resources/capa-component.properties
@@ -1,0 +1,2 @@
+group.rxcloud.capa.component.http.CapaHttp=group.rxcloud.capa.spi.aws.mesh.http.AwsCapaHttp
+group.rxcloud.capa.spi.config.CapaSpiOptionsLoader=group.rxcloud.capa.spi.aws.mesh.config.AwsSpiOptionsLoader

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,10 @@
     </distributionManagement>
 
     <modules>
-        <module>sdk-spi-aws</module>
+        <module>capa-spi-aws</module>
+        <module>capa-spi-aws-mesh</module>
+        <module>capa-spi-aws-config</module>
+        <module>capa-spi-aws-infrastructure</module>
     </modules>
 
     <properties>
@@ -87,6 +90,23 @@
                 <groupId>group.rxcloud</groupId>
                 <artifactId>capa-sdk-spi</artifactId>
                 <version>${capa.version}</version>
+            </dependency>
+
+            <!-- SDK modules -->
+            <dependency>
+                <groupId>group.rxcloud</groupId>
+                <artifactId>capa-spi-aws-infrastructure</artifactId>
+                <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>group.rxcloud</groupId>
+                <artifactId>capa-spi-aws-mesh</artifactId>
+                <version>${revision}</version>
+            </dependency>
+            <dependency>
+                <groupId>group.rxcloud</groupId>
+                <artifactId>capa-spi-aws-config</artifactId>
+                <version>${revision}</version>
             </dependency>
 
             <!-- aws sdk v2 -->

--- a/sdk-spi-aws/src/main/resources/capa-component.properties
+++ b/sdk-spi-aws/src/main/resources/capa-component.properties
@@ -1,2 +1,0 @@
-group.rxcloud.capa.component.http.CapaHttp=group.rxcloud.capa.spi.aws.http.AwsCapaHttp
-group.rxcloud.capa.spi.config.CapaSpiOptionsLoader=group.rxcloud.capa.spi.aws.config.AwsSpiOptionsLoader


### PR DESCRIPTION
# Description

The module of sdk-spi-aws contains too many middleware, it is separated by the type of middleware

## Issue reference

#7 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
