### PR TITLE
feature:change getconfig impl to cache locally and update by polling …

### DIFF
--- a/capa-spi-aws-config/pom.xml
+++ b/capa-spi-aws-config/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>capa-aws-parent</artifactId>
         <groupId>group.rxcloud</groupId>
-        <version>1.10.12.3.RELEASE</version>
+        <version>1.10.12.4.RELEASE</version>
     </parent>
 
     <artifactId>capa-spi-aws-config</artifactId>

--- a/capa-spi-aws-config/src/main/java/group/rxcloud/capa/spi/aws/config/entity/Configuration.java
+++ b/capa-spi-aws-config/src/main/java/group/rxcloud/capa/spi/aws/config/entity/Configuration.java
@@ -36,9 +36,8 @@ public class Configuration<T> {
     public String toString() {
         return "Configuration{" +
                 "clientConfigurationVersion='" + clientConfigurationVersion + '\'' +
-                ", configurationItem=" + configurationItem +
-                ", lock=" + lock +
-                ", listeners=" + listeners +
+                ", configurationItem=" + configurationItem.getContent().toString() +
+                ", listenersCount=" + listeners.size() +
                 ", initialized=" + initialized +
                 ", subscribed=" + subscribed +
                 '}';

--- a/capa-spi-aws-config/src/test/java/group/rxcloud/capa/spi/aws/config/AwsCapaConfigStoreIgnoreTest.java
+++ b/capa-spi-aws-config/src/test/java/group/rxcloud/capa/spi/aws/config/AwsCapaConfigStoreIgnoreTest.java
@@ -52,6 +52,21 @@ class AwsCapaConfigStoreIgnoreTest {
         Mono<List<ConfigurationItem<User>>> mono2 = ins.doGet("100012345", "", "", Lists.newArrayList("test1.json"), new HashMap<>(), TypeRef.get(User.class));
         System.out.println(mono2.block().get(0).getContent().getAge());
 
+        Flux<SubscribeResp<User>> flux1 = ins.doSubscribe("100012345", "", "", Lists.newArrayList("test1.json"), new HashMap<>(), TypeRef.get(User.class));
+        flux1.subscribe(resp -> {
+            System.out.println("1:"+resp.getItems().get(0).getContent().getAge());
+        });
+
+        long start = System.currentTimeMillis();
+        while(System.currentTimeMillis()-start<20000){
+
+        }
+        //change config
+        Mono<List<ConfigurationItem<User>>> mono3 = ins.doGet("100012345", "", "", Lists.newArrayList("test1.json"), new HashMap<>(), TypeRef.get(User.class));
+        System.out.println(mono3.block().get(0).getContent().getAge());
+
+        System.out.println("");
+
 //        Mono<List<ConfigurationItem<User>>> mono = ins.doGet("100012345", "", "", Lists.newArrayList("test1.json"), new HashMap<>(), TypeRef.get(User.class));
 //        System.out.println(mono.block().get(0).getContent().getAge());
 //

--- a/capa-spi-aws-infrastructure/pom.xml
+++ b/capa-spi-aws-infrastructure/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>capa-aws-parent</artifactId>
         <groupId>group.rxcloud</groupId>
-        <version>1.10.12.3.RELEASE</version>
+        <version>1.10.12.4.RELEASE</version>
     </parent>
 
     <artifactId>capa-spi-aws-infrastructure</artifactId>

--- a/capa-spi-aws-log/pom.xml
+++ b/capa-spi-aws-log/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>capa-aws-parent</artifactId>
         <groupId>group.rxcloud</groupId>
-        <version>1.10.12.3.RELEASE</version>
+        <version>1.10.12.4.RELEASE</version>
     </parent>
 
     <artifactId>capa-spi-aws-log</artifactId>

--- a/capa-spi-aws-mesh/pom.xml
+++ b/capa-spi-aws-mesh/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>capa-aws-parent</artifactId>
         <groupId>group.rxcloud</groupId>
-        <version>1.10.12.3.RELEASE</version>
+        <version>1.10.12.4.RELEASE</version>
     </parent>
 
     <artifactId>capa-spi-aws-mesh</artifactId>

--- a/capa-spi-aws-telemetry/pom.xml
+++ b/capa-spi-aws-telemetry/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>capa-aws-parent</artifactId>
         <groupId>group.rxcloud</groupId>
-        <version>1.10.12.3.RELEASE</version>
+        <version>1.10.12.4.RELEASE</version>
     </parent>
 
     <artifactId>capa-spi-aws-telemetry</artifactId>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>capa-aws-parent</artifactId>
         <groupId>group.rxcloud</groupId>
-        <version>1.10.12.3.RELEASE</version>
+        <version>1.10.12.4.RELEASE</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>group.rxcloud</groupId>
     <artifactId>capa-aws-parent</artifactId>
     <packaging>pom</packaging>
-    <version>1.10.12.3.RELEASE</version>
+    <version>1.10.12.4.RELEASE</version>
     <name>capa-aws-parent</name>
     <description>AWS for Capa.</description>
     <url>https://github.com/reactivegroup</url>


### PR DESCRIPTION
…periodly

# Description

当前getconfig是直接调用appconfig sdk获取配置，频繁使用会使用调用费用昂贵。接入方可能不理解此方法的真实使用场景，进行滥用，导致费用飙升。现将里面的逻辑改成和subscribe逻辑一致，自己维护配置的更新，每次返回配置，从本地拉取。

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #76 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [√ ] Code compiles correctly
* [√ ] Created/updated tests
* [ √] Extended the documentation
